### PR TITLE
fix out-of-index bugs

### DIFF
--- a/sat/data_video.py
+++ b/sat/data_video.py
@@ -378,8 +378,9 @@ class SFTDataset(Dataset):
                         num_frames = max_num_frames
                         start = int(skip_frms_num)
                         end = int(start + num_frames / fps * actual_fps)
-                        indices = np.arange(start, end, (end - start) / num_frames).astype(int)
-                        temp_frms = vr.get_batch(np.arange(start, end))
+                        end_safty = min(int(start + num_frames / fps * actual_fps), int(ori_vlen))
+                        indices = np.arange(start, end, (end - start) // num_frames).astype(int)
+                        temp_frms = vr.get_batch(np.arange(start, end_safty))
                         assert temp_frms is not None
                         tensor_frms = torch.from_numpy(temp_frms) if type(temp_frms) is not torch.Tensor else temp_frms
                         tensor_frms = tensor_frms[torch.tensor((indices - start).tolist())]
@@ -388,7 +389,7 @@ class SFTDataset(Dataset):
                             num_frames = max_num_frames
                             start = int(skip_frms_num)
                             end = int(ori_vlen - skip_frms_num)
-                            indices = np.arange(start, end, (end - start) / num_frames).astype(int)
+                            indices = np.arange(start, end, (end - start) // num_frames).astype(int)
                             temp_frms = vr.get_batch(np.arange(start, end))
                             assert temp_frms is not None
                             tensor_frms = (


### PR DESCRIPTION
这里修改了两部分
1. end_safty是为了避免某些情况下temp_frms出现索引超出的情况，如end = int(start + num_frames / fps * actual_fps) #  (3 +    49/8 * 25 = 3   + 153)  int(156.125) 156  ori_vlen:154 [0, 153]  index[154,155] > 153
2. 测试第二个indices = np.arange(start, end, (end - start) / num_frames).astype(int)会有bug，也会出现期望外的值
>>> np.arange(3,122,(122-3)/49).astype(int)
array([  3,   5,   7,  10,  12,  15,  17,  20,  22,  24,  27,  29,  32,
        34,  37,  39,  41,  44,  46,  49,  51,  54,  56,  58,  61,  63,
        66,  68,  71,  73,  75,  78,  80,  83,  85,  88,  90,  92,  95,
        97, 100, 102, 105, 107, 109, 112, 114, 117, 119, 122])
>>> np.arange(3,122,(122-3)//49).astype(int)
array([  3,   5,   7,   9,  11,  13,  15,  17,  19,  21,  23,  25,  27,
        29,  31,  33,  35,  37,  39,  41,  43,  45,  47,  49,  51,  53,
        55,  57,  59,  61,  63,  65,  67,  69,  71,  73,  75,  77,  79,
        81,  83,  85,  87,  89,  91,  93,  95,  97,  99, 101, 103, 105,
       107, 109, 111, 113, 115, 117, 119, 121])
可以发现原来的方法产生的索引122溢出了，但是按照语法不应该出现这种情况，我也不懂，跑测试发现的问题
测试环境：
Ubuntu 22.04.2 LTS
conda 24.1.2 
Python 3.10.14  
numpy 1.26.4
