### PR TITLE
Remove to device to avoid memory allocation errors

### DIFF
--- a/inference/gradio_web_demo.py
+++ b/inference/gradio_web_demo.py
@@ -19,9 +19,8 @@ from openai import OpenAI
 import moviepy.editor as mp
 
 dtype = torch.bfloat16
-device = "cuda"  # Need to use cuda
 
-pipe = CogVideoXPipeline.from_pretrained("THUDM/CogVideoX-5b", torch_dtype=dtype).to(device)
+pipe = CogVideoXPipeline.from_pretrained("THUDM/CogVideoX-5b", torch_dtype=dtype)
 pipe.enable_model_cpu_offload()
 pipe.enable_sequential_cpu_offload()
 pipe.vae.enable_slicing()


### PR DESCRIPTION
Remove to(device), so it will apply the memory settings first