### PR TITLE
rile padding fix

### DIFF
--- a/inference/gradio_composite_demo/README.md
+++ b/inference/gradio_composite_demo/README.md
@@ -43,3 +43,8 @@ pip install -r requirements.txt
 ```bash
 python gradio_web_demo.py
 ```
+
+
+### known issue
+
+The known issue is that RIFE may experience precision overflow on different devices, resulting in incorrect image colors. 

--- a/inference/gradio_composite_demo/rife_model.py
+++ b/inference/gradio_composite_demo/rife_model.py
@@ -19,7 +19,7 @@ def pad_image(img, scale):
     tmp = max(32, int(32 / scale))
     ph = ((h - 1) // tmp + 1) * tmp
     pw = ((w - 1) // tmp + 1) * tmp
-    padding = (0, 0, pw - w, ph - h)
+    padding = (0, pw - w, 0,  ph - h)
     return F.pad(img, padding)
 
 


### PR DESCRIPTION
 Fix the damn jitter issue already

The known issue is that RIFE may experience precision overflow on different devices, resulting in incorrect image colors. 