### PR TITLE
DynamicCFG timesteps seems not correct in SAT version

### DIFF
--- a/sat/sgm/modules/diffusionmodules/sampling.py
+++ b/sat/sgm/modules/diffusionmodules/sampling.py
@@ -515,7 +515,10 @@ class VideoDDIMSampler(BaseDiffusionSampler):
             ).to(torch.float32)
             if isinstance(self.guider, DynamicCFG):
                 denoised = self.guider(
-                    denoised, (1 - alpha_cumprod_sqrt**2) ** 0.5, step_index=self.num_steps - timestep, scale=scale
+                    denoised,
+                    (1 - alpha_cumprod_sqrt**2) ** 0.5,
+                    step_index=self.discretization.num_steps - timestep,
+                    scale=scale,
                 )
             else:
                 denoised = self.guider(denoised, (1 - alpha_cumprod_sqrt**2) ** 0.5, scale=scale)


### PR DESCRIPTION
Here looks like a small bug for SAT version, which will cause incorrect step arg pass to dynamic cfg. 

Good news is Diffusers version is correct. https://github.com/huggingface/diffusers/blob/8cdcdd9e32925200ce5e1cf410fe14a774f3c3a6/src/diffusers/pipelines/cogvideo/pipeline_cogvideox.py#L683
