### PR TITLE
fix: division by zero error at create video indices

### DIFF
--- a/sat/data_video.py
+++ b/sat/data_video.py
@@ -408,7 +408,7 @@ class SFTDataset(Dataset):
                 num_frames = self.max_num_frames
                 start = int(self.skip_frms_num)
                 end = int(ori_vlen - self.skip_frms_num)
-                indices = np.arange(start, end, (end - start) // num_frames).astype(int)
+                indices = np.arange(start, end, max((end - start) // num_frames), 1).astype(int)
                 temp_frms = vr.get_batch(np.arange(start, end))
                 assert temp_frms is not None
                 tensor_frms = (


### PR DESCRIPTION
The issue occurs due to skip_frms_num, where in the current code, 
`indices = np.arange(start, end, (end - start) // num_frames).astype(int)`, 
there are cases where end - start < num_frames, leading to a division-by-zero error. 