### PR TITLE
fix deprecation of clear_objs_and_retain_memory

### DIFF
--- a/finetune/train_cogvideox_lora.py
+++ b/finetune/train_cogvideox_lora.py
@@ -40,7 +40,7 @@ from diffusers.optimization import get_scheduler
 from diffusers.pipelines.cogvideo.pipeline_cogvideox import get_resize_crop_region_for_grid
 from diffusers.training_utils import (
     cast_training_params,
-    clear_objs_and_retain_memory,
+    free_memory,
 )
 from diffusers.utils import check_min_version, convert_unet_state_dict_to_peft, export_to_video, is_wandb_available
 from diffusers.utils.hub_utils import load_or_create_model_card, populate_model_card
@@ -726,7 +726,7 @@ def log_validation(
                 }
             )
 
-    clear_objs_and_retain_memory([pipe])
+    free_memory()
 
     return videos
 


### PR DESCRIPTION
The API of diffusers `clear_objs_and_retain_memory` has been deprecated in [huggingface/diffusers#9543](https://github.com/huggingface/diffusers/pull/9543/files#diff-5c07adf115dbb937f26dbfedff2aef0d31b4e8e3a58ba9cfb4a0c9f64672a8c5L263) and is replaced with `free_memory`. Therefore, the corresponding parts in the LoRA training script need to be adjusted to adapt to the latest version of diffusers.