### PR TITLE
[Bug] fix parallel rand device & set dynamic cfg

### DIFF
--- a/tools/parallel_inference/parallel_inference_xdit.py
+++ b/tools/parallel_inference/parallel_inference_xdit.py
@@ -78,8 +78,9 @@ def main():
         num_frames=input_config.num_frames,
         prompt=input_config.prompt,
         num_inference_steps=input_config.num_inference_steps,
-        generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
+        generator=torch.Generator().manual_seed(input_config.seed),
         guidance_scale=6,
+        use_dynamic_cfg=True,
     ).frames[0]
 
     end_time = time.time()


### PR DESCRIPTION
修复示例中分布式推理结果与单卡结果差异大的问题：
- generator不同的device生成是不一样的，parallel inference使用了cuda，而inference/cli_demo.py使用cpu，就算使用相同的seed，产生的随机数也是不一样，因而初始latents不一样，从而导致后续结果差异变大。
- parallel inference没有使用dynamic_cfg，而inference/cli_demo.py中使用dynamic_cfg
- 采样器不一致，parallel inference的xFuserPipeline默认读取config中的DDIM，inference/cli_demo.py中则手动改成了DPM

本PR修复前2个问题。
@zRzRzRzRzRzRzR 