### PR TITLE
Fix Moviepy compatibility issue and update README instructions

### DIFF
--- a/inference/gradio_composite_demo/README.md
+++ b/inference/gradio_composite_demo/README.md
@@ -10,12 +10,12 @@ suggested_storage: large
 app_port: 7860
 app_file: app.py
 models:
-  - THUDM/CogVideoX-5b
+  - THUDM/CogVideoX-5b-I2V
 tags:
   - cogvideox
   - video-generation
   - thudm
-short_description: Text-to-Video
+short_description: Image-to-Video
 disable_embedding: false
 ---
 
@@ -41,7 +41,7 @@ pip install -r requirements.txt
 ## Running the code
 
 ```bash
-python gradio_web_demo.py
+python app.py
 ```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ gradio>=5.5.0
 imageio>=2.35.1
 imageio-ffmpeg>=0.5.1
 openai>=1.54.0
-moviepy>=1.0.3
+moviepy==1.0.3
 scikit-video>=1.1.11


### PR DESCRIPTION

This pull request addresses two changes:

1. **Updated README Running Code Instructions**  
   Fixed metadata for huggingface and the running code instruction.

2. **Fixed Moviepy Compatibility Issue**  
   Moviepy recently released version 2, which introduced major breaking changes. The current code fails with the error:  
   ```
   moviepy.editor is not a module # line 33 of app.py
   ```  
   This PR proposes **two potential fixes** for the issue:  
   - **Fix 1:** Pin the Moviepy version to `1.0.3` (the last version of v1), which ensures compatibility with the current implementation. However, note that v1 is no longer maintained.  (Implemented in this PR)
   - **Fix 2:** Update the import statement and usage to comply with Moviepy v2, as outlined in the [official migration guide](https://zulko.github.io/moviepy/getting_started/updating_to_v2.html). For example:  
     ```python
     from moviepy import VideoFileClip
     ```  
     And update line 274 from `mp.VideoFileClip(video_path)` to `VideoFileClip(video_path)`.

---

**Recommendation:**  
I recommend implementing **Fix 2** (updating to Moviepy v2) as it ensures compatibility with the latest version and future updates. However, I’ve included **Fix 1** as a temporary solution if upgrading to v2 is not feasible at this time.