### PR TITLE
docs: clarify frame number requirements for CogVideoX models

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ models we currently offer, along with their foundational information.
     <td colspan="3" style="text-align: center;">720 * 480</td>
   </tr>
   <tr>
+    <td style="text-align: center;">Number of Frames</td>
+    <td colspan="2" style="text-align: center;">Should be <b>16N + 1</b> where N <= 10 (default 81)</td>
+    <td colspan="3" style="text-align: center;">Should be <b>8N + 1</b> where N <= 6 (default 49)</td>
+  </tr>
+  <tr>
     <td style="text-align: center;">Inference Precision</td>
     <td colspan="2" style="text-align: center;"><b>BF16 (Recommended)</b>, FP16, FP32, FP8*, INT8, Not supported: INT4</td>
     <td style="text-align: center;"><b>FP16*(Recommended)</b>, BF16, FP32, FP8*, INT8, Not supported: INT4</td>

--- a/README_ja.md
+++ b/README_ja.md
@@ -192,6 +192,11 @@ CogVideoXは、[清影](https://chatglm.cn/video?fr=osm_cogvideox) と同源の�
     <td colspan="3" style="text-align: center;">720 * 480</td>
   </tr>
   <tr>
+    <td style="text-align: center;">フレーム数</td>
+    <td colspan="2" style="text-align: center;"><b>16N + 1</b> (N <= 10) である必要があります (デフォルト 81)</td>
+    <td colspan="3" style="text-align: center;"><b>8N + 1</b> (N <= 6) である必要があります (デフォルト 49)</td>
+  </tr>
+  <tr>
     <td style="text-align: center;">推論精度</td>
     <td colspan="2" style="text-align: center;"><b>BF16(推奨)</b>, FP16, FP32，FP8*，INT8，INT4非対応</td>
     <td style="text-align: center;"><b>FP16*(推奨)</b>, BF16, FP32，FP8*，INT8，INT4非対応</td>

--- a/README_zh.md
+++ b/README_zh.md
@@ -180,7 +180,12 @@ CogVideoX是 [清影](https://chatglm.cn/video?fr=osm_cogvideox) 同源的开源
     <td colspan="1" style="text-align: center;">1360 * 768</td>
     <td colspan="1" style="text-align: center;"> Min(W, H) = 768 <br> 768 ≤ Max(W, H) ≤ 1360 <br> Max(W, H) % 16 = 0 </td>
     <td colspan="3" style="text-align: center;">720 * 480</td>
-    </tr>
+  </tr>
+  <tr>
+    <td style="text-align: center;">帧数</td>
+    <td colspan="2" style="text-align: center;">必须为 <b>16N + 1</b> 其中 N <= 10 (默认 81)</td>
+    <td colspan="3" style="text-align: center;">必须为 <b>8N + 1</b> 其中 N <= 6 (默认 49)</td>
+  </tr>
   <tr>
     <td style="text-align: center;">推理精度</td>
     <td colspan="2" style="text-align: center;"><b>BF16(推荐)</b>, FP16, FP32，FP8*，INT8，不支持INT4</td>

--- a/inference/cli_demo.py
+++ b/inference/cli_demo.py
@@ -100,7 +100,7 @@ def generate_video(
     if width is None or height is None:
         height, width = desired_resolution
         logging.info(f"\033[1mUsing default resolution {desired_resolution} for {model_name}\033[0m")
-    elif (width, height) != desired_resolution:
+    elif (height, width) != desired_resolution:
         if generate_type == "i2v":
             # For i2v models, use user-defined width and height
             logging.warning(
@@ -111,7 +111,7 @@ def generate_video(
             logging.warning(
                 f"\033[1;31m{model_name} is not supported for custom resolution. Setting back to default resolution {desired_resolution}.\033[0m"
             )
-            width, height = desired_resolution
+            height, width = desired_resolution
 
     if generate_type == "i2v":
         pipe = CogVideoXImageToVideoPipeline.from_pretrained(model_path, torch_dtype=dtype)


### PR DESCRIPTION
Specify that frame numbers must be:
- 16N + 1 (N <= 10) for CogVideoX1.5-5B models
- 8N + 1 (N <= 6) for CogVideoX-2B/5B models